### PR TITLE
reset the type of a flight after booking

### DIFF
--- a/src/guis/flights.cljc
+++ b/src/guis/flights.cljc
@@ -105,7 +105,8 @@
       (str ", returning on " (:value (::return-date form-state))))
     "."]
    [:button.btn
-    {:on {:click [[:action/assoc-in [::booked?] false]]}}
+    {:on {:click [[:action/assoc-in [::booked?] false]
+                  [:action/assoc-in [::type] :one-way]]}}
     "Try again"]])
 
 (defn render-ui [state]


### PR DESCRIPTION
Before this change, after you've booked a roundtrip flight and returned to the main screen, the UI would show "one-way" in the drop-down menu, but both date fields would be available and clicking the button would book a roundtrip flight.